### PR TITLE
BUG: When waiting for the service to start, the wrong error was being…

### DIFF
--- a/runPerf.ps1
+++ b/runPerf.ps1
@@ -49,9 +49,9 @@ Function Get-StatusCode {
     try{
         (Invoke-WebRequest -Uri "http://$h/$c" -UseBasicParsing -DisableKeepAlive).StatusCode
     }
-    catch [Net.WebException]
+    catch
     {
-        [int]$_.Exception.Response.StatusCode
+        0
     }
 }
 


### PR DESCRIPTION
… caught.

The error thrown when calling `Invoke-WebRequest` is actually an `ErrorRecord`, and thus was not caught. This meant that the retry for 60 seconds did not happen, and the script could only continue if the request succeeded first try. All error types are now caught, and 0 returned.