### PR TITLE
Update regex to detect `httpd-2.4.58-310124-win64-VS17.zip`.

### DIFF
--- a/GetVer.ps1
+++ b/GetVer.ps1
@@ -1,5 +1,5 @@
 $resp = Invoke-WebRequest -URI https://www.apachelounge.com/download/VS17/ -UserAgent "CMake"
-If ($resp.Content -match "httpd-2.4.\d+-win64-VS17.zip")
+If ($resp.Content -match "httpd-2\.4\.(\d+)(-\d+)?-win64-VS17\.zip")
 {
   $ver = $Matches[0] -replace "^.*httpd-2.4.(\d+).*", '$1'
 }


### PR DESCRIPTION
### Changes
- Add second optional group (matching `-310124` fragment).
- Escape period characters.