### PR TITLE
Add an optional concurrency argument to the performance scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,6 @@ Scripts are provided for both Powershell and Bash as part of the build. These ar
 ```
 bin\runPerf.ps1 -h http://127.0.0.1:3000 -n 2000 -s "php -S 127.0.0.1:3000 -t C:\inetpub\wwwroot" -c calibrate.php -p process.php 
 ```
+### Concurrency
+
+Both scripts accept an optional concurrency argument, which sets the number of concurrent requests ApacheBench makes (the `-c` option to `ab`). It defaults to 1, a single request at a time, so existing usage is unchanged. Pass `-k` (Bash also accepts `--concurrency`) to raise it, for example `-k 4` to load the service with four concurrent requests.

--- a/runPerf.ps1
+++ b/runPerf.ps1
@@ -1,4 +1,4 @@
-﻿param ($h, $s, $c, $p, $n, $conf)
+﻿param ($h, $s, $c, $p, $n, $conf, $k=1)
 
 $scriptRoot = Split-Path -Parent -Path $MyInvocation.MyCommand.Definition
 
@@ -28,6 +28,7 @@ if ($h -eq $null -or
 	Write-Host "    -s : command to start the web service e.g. `"php -S localhost:3000`""
     Write-Host "    -c : endpoint path to use for calibration on the host e.g. test/calibrate"
     Write-Host "    -p : endpoint path to use for the process pass on the host e.g. test/process"
+    Write-Host "    -k : number of concurrent requests to make (default 1)"
 	Write-Host ""
 	Write-Host "For example:"
 	Write-Host "    runPerf.ps1 -host localhost:3000 -passes 1000 -service-start `"php -S localhost:3000`" ..."
@@ -39,6 +40,7 @@ Write-Host "Passes                   = $n"
 Write-Host "Service Start            = $s"
 Write-Host "Calibration Endpoint     = $c"
 Write-Host "Process Endpoint         = $p"
+Write-Host "Concurrency              = $k"
 
 Write-Host "Starting the service"
 $serviceProcess = Start-Process pwsh -argument "-command `"$s`"" -RedirectStandardError "$scriptRoot/service-$conf.error.out" -RedirectStandardOutput "$scriptRoot/service-$conf.out" –PassThru -NoNewWindow
@@ -66,9 +68,9 @@ While ($HTTP_Status -ne 200 -And $Tries -le 12) {
 
 # Run the benchmarks
 Write-Host "Running calibration"
-Invoke-Expression "$ab -U $ScriptRoot/uas.csv -q -n $n $h/$c >$calOut"
+Invoke-Expression "$ab -U $ScriptRoot/uas.csv -q -c $k -n $n $h/$c >$calOut"
 Write-Host "Running processing"
-Invoke-Expression "$ab -U $ScriptRoot/uas.csv -q -n $n $h/$p >$proOut"
+Invoke-Expression "$ab -U $ScriptRoot/uas.csv -q -c $k -n $n $h/$p >$proOut"
 
 # Check no requests failed in calibration
 $failedCal = Get-Content $calOut | Select-String -Pattern "Failed requests"

--- a/runPerf.sh
+++ b/runPerf.sh
@@ -7,6 +7,7 @@ SUMMARY_OUT=summary.json
 AB=`dirname $0`/ab
 UAS=`dirname $0`/uas.csv
 ALLOWED_OVERHEAD_MS=200
+CONCURRENCY=1
 
 while [[ $# -gt 0 ]]
 do
@@ -38,6 +39,11 @@ case $key in
     shift # past argument
     shift # past value
     ;;
+    -k|--concurrency)
+    CONCURRENCY="$2"
+    shift # past argument
+    shift # past value
+    ;;
     *)    # unknown option
     shift # past argument
     ;;
@@ -54,6 +60,7 @@ then
 	echo "    -s | --service-start          : command to start the web service e.g. \"php -S localhost:3000\""
     echo "    -c | --calibration-endpoint   : endpoint path to use for calibration on the host e.g. test/calibrate"
     echo "    -p | --process-endpoint       : endpoint path to use for the process pass on the host e.g. test/process"
+    echo "    -k | --concurrency            : number of concurrent requests to make (default 1)"
 	echo ""
 	echo "For example:"
 	echo "    runPerf.bat -host localhost:3000 -passes 1000 -service-start \"php -S localhost:3000\" ..."
@@ -65,6 +72,7 @@ echo "Passes                   = ${PASSES}"
 echo "Service Start            = ${SERVICE_START}"
 echo "Calibration Endpoint     = ${CAL_END}"
 echo "Process Endpoint         = ${PRO_END}"
+echo "Concurrency              = ${CONCURRENCY}"
 
 # Function for arithmetic
 calc() { awk "BEGIN{print $*}"; }
@@ -90,9 +98,9 @@ fi
 
 # Run the benchmarks
 echo "Running calibration"
-$AB -U $UAS -q -n $PASSES $HOST/$CAL_END >$CAL_OUT
+$AB -U $UAS -q -c $CONCURRENCY -n $PASSES $HOST/$CAL_END >$CAL_OUT
 echo "Running processing"
-$AB -U $UAS -q -n $PASSES $HOST/$PRO_END >$PRO_OUT
+$AB -U $UAS -q -c $CONCURRENCY -n $PASSES $HOST/$PRO_END >$PRO_OUT
 
 # Stop the service
 kill $SERVICE_PID


### PR DESCRIPTION
## Summary

The `runPerf` scripts always ran ApacheBench at its default concurrency of one request at a time, so a benchmarked service was only ever exercised by a single connection. This is fine for measuring single-request overhead but means a multi-worker service such as Nginx is never loaded across its workers.

## Change

Both `runPerf.sh` and `runPerf.ps1` gain a concurrency argument, passed through as the `ab -c` option:

- Bash: `-k` or `--concurrency`
- PowerShell: `-k`

It defaults to 1, so every existing caller is unchanged. The README documents the new option.

## Verification

Built `ab` and ran the patched `runPerf.sh` against a local Nginx, confirming the requested concurrency is applied (ApacheBench reports `Concurrency Level: 4`) and throughput scales (2,630 req/s at `-k 1` to 5,912 req/s at `-k 4`, 0 failed requests). The committed `runPerf.sh` retains LF line endings.