### PR TITLE
Add evidence file support to send full request header sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,13 @@ bin\runPerf.ps1 -h http://127.0.0.1:3000 -n 2000 -s "php -S 127.0.0.1:3000 -t C:
 ### Concurrency
 
 Both scripts accept an optional concurrency argument, which sets the number of concurrent requests ApacheBench makes (the `-c` option to `ab`). It defaults to 1, a single request at a time, so existing usage is unchanged. Pass `-k` (Bash also accepts `--concurrency`) to raise it, for example `-k 4` to load the service with four concurrent requests.
+
+## Evidence Records
+
+By default each request carries a single random User-Agent (the `-U` option, see above). Device detection can also use other request headers, such as the `Sec-CH-UA` client hint headers, so a more representative benchmark sends a full set of headers per request.
+
+Pass `-E` (Bash `runPerf.sh` also accepts `--evidence`) with a YAML evidence file, as published in the [51Degrees data repository](https://github.com/51Degrees/device-detection-data) (for example `20000 Evidence Records.yml`). The file is a sequence of records separated by `---`, each a set of `header.<name>: <value>` lines. For every request `ab` picks a record at random and sends all of its headers. When an evidence file is given it is used instead of the User-Agents file.
+
+```
+./ab -E "20000 Evidence Records.yml" -c 10 -n 10000 http://127.0.0.1:8081/
+```

--- a/ab.c
+++ b/ab.c
@@ -326,6 +326,15 @@ char userAgents[USERAGENT_COUNT][USERAGENT_MAX_LENGTH];
 int userAgentsCount = 0;
 int userAgentRandomCharacters = 0;
 
+/* array of evidence records. Each entry is a ready to send block of HTTP
+ * header lines (Name: Value\r\n), built from one record of a YAML evidence
+ * file so that a request can carry a full set of headers rather than a
+ * single User-Agent. */
+#define EVIDENCE_COUNT 20000
+#define EVIDENCE_MAX_LENGTH 2048
+char evidenceRecords[EVIDENCE_COUNT][EVIDENCE_MAX_LENGTH];
+int evidenceRecordsCount = 0;
+
 /* overrides for ab-generated common headers */
 int opt_host = 0;       /* was an optional "Host:" header specified? */
 int opt_useragent = 0;  /* was an optional "User-Agent:" header specified? */
@@ -691,8 +700,38 @@ static void write_request(struct connection * c)
         "X-OperaMini-Phone-UA" };
     apr_size_t uniqueRequestLength;
 
+    /* When an evidence file is loaded, replace the default User-Agent line
+     * with the full block of headers from a randomly chosen evidence
+     * record, so that each request carries a complete, realistic set of
+     * evidence rather than a single User-Agent. */
+    if (evidenceRecordsCount != 0) {
+        const char *record = evidenceRecords[rand() % evidenceRecordsCount];
+        src = request;
+        dst = uniqueRequest;
+        while (*src != 0) {
+            if (strncmp(src, USER_AGENT_HEADER, sizeof(USER_AGENT_HEADER) - 1) == 0) {
+                dst += snprintf(dst,
+                    uniqueRequest + sizeof(uniqueRequest) - dst,
+                    "%s",
+                    record);
+                /* Skip the template's User-Agent line. */
+                while (*src != '\n' && *src != 0) {
+                    src++;
+                }
+                if (*src == '\n') {
+                    src++;
+                }
+            } else {
+                *dst = *src;
+                dst++;
+                src++;
+            }
+        }
+        *dst = 0;
+        uniqueRequestLength = dst - uniqueRequest;
+    }
     /* modify request each time to append data from request file */
-    if (userAgentsCount != 0) {
+    else if (userAgentsCount != 0) {
         src = request;
         dst = uniqueRequest;
         while (*src != 0) {
@@ -1670,6 +1709,81 @@ void initUserAgents(const char *userAgentFilePath) {
     fclose(userAgentsFile);
 }
 
+/*
+ * Load a YAML evidence file, as produced by the 51Degrees data
+ * repository (for example "20000 Evidence Records.yml"). The format is a
+ * sequence of records separated by a "---" line, each record being one or
+ * more "header.<name>: <value>" lines. Values that contain reserved YAML
+ * characters are wrapped in single quotes which are stripped here. Each
+ * record is stored as a block of "<name>: <value>\r\n" header lines ready
+ * to be written straight into a request.
+ */
+void initEvidence(const char *evidenceFilePath) {
+    FILE *evidenceFile = fopen(evidenceFilePath, "r");
+    char line[EVIDENCE_MAX_LENGTH];
+    int inRecord = 0;
+    if (evidenceFile == NULL) {
+        fprintf(stderr, "Could not open evidence file '%s'\n", evidenceFilePath);
+        return;
+    }
+    evidenceRecords[0][0] = 0;
+    while (fgets(line, sizeof(line), evidenceFile) != NULL) {
+        size_t len = strlen(line);
+        char *name, *colon, *value;
+        size_t valueLength, used;
+
+        /* Strip the trailing line ending. */
+        while (len > 0 && (line[len - 1] == '\n' || line[len - 1] == '\r')) {
+            line[--len] = 0;
+        }
+
+        /* A "---" line marks the boundary between records. */
+        if (strcmp(line, "---") == 0) {
+            if (inRecord && evidenceRecords[evidenceRecordsCount][0] != 0) {
+                evidenceRecordsCount++;
+                if (evidenceRecordsCount >= EVIDENCE_COUNT) {
+                    break;
+                }
+                evidenceRecords[evidenceRecordsCount][0] = 0;
+            }
+            inRecord = 1;
+            continue;
+        }
+
+        /* Only "header.<name>: <value>" lines are used. */
+        if (!inRecord || strncmp(line, "header.", 7) != 0) {
+            continue;
+        }
+        name = line + 7;
+        colon = strstr(name, ": ");
+        if (colon == NULL) {
+            continue;
+        }
+        *colon = 0;
+        value = colon + 2;
+
+        /* Remove the single quotes YAML uses to escape some values. */
+        valueLength = strlen(value);
+        if (valueLength >= 2 && value[0] == '\'' && value[valueLength - 1] == '\'') {
+            value[valueLength - 1] = 0;
+            value++;
+        }
+
+        used = strlen(evidenceRecords[evidenceRecordsCount]);
+        snprintf(evidenceRecords[evidenceRecordsCount] + used,
+            EVIDENCE_MAX_LENGTH - used, "%s: %s\r\n", name, value);
+    }
+
+    /* Commit the final record. */
+    if (inRecord && evidenceRecordsCount < EVIDENCE_COUNT
+        && evidenceRecords[evidenceRecordsCount][0] != 0) {
+        evidenceRecordsCount++;
+    }
+
+    fclose(evidenceFile);
+    fprintf(stderr, "Loaded %d evidence records.\n", evidenceRecordsCount);
+}
+
 /* --------------------------------------------------------- */
 
 /* run the tests */
@@ -1978,6 +2092,8 @@ static void usage(const char *progname)
     fprintf(stderr, "    -H attribute    Add Arbitrary header line, eg. 'Accept-Encoding: gzip'\n");
     fprintf(stderr, "                    Inserted after all normal header lines. (repeatable)\n");
     fprintf(stderr, "    -U filename     File of User-Agents to use randomly for each request\n");
+    fprintf(stderr, "    -E filename     YAML evidence file whose records are sent as the\n");
+    fprintf(stderr, "                    request headers, one record chosen at random per request\n");
     fprintf(stderr, "    -R characters   Number of characters in User-Agents to change randomly\n");
     fprintf(stderr, "    -A attribute    Add Basic WWW Authentication, the attributes\n");
     fprintf(stderr, "                    are a colon separated username and password.\n");
@@ -2160,7 +2276,7 @@ int main(int argc, const char * const argv[])
 #endif
 
     apr_getopt_init(&opt, cntxt, argc, argv);
-    while ((status = apr_getopt(opt, "R:U:n:c:t:b:T:p:v:rkVhwix:y:z:C:H:P:A:g:X:de:Sq"
+    while ((status = apr_getopt(opt, "R:U:E:n:c:t:b:T:p:v:rkVhwix:y:z:C:H:P:A:g:X:de:Sq"
 #ifdef USE_SSL
             "Z:f:"
 #endif
@@ -2320,6 +2436,9 @@ int main(int argc, const char * const argv[])
                 break;
             case 'U':
                 initUserAgents(optarg);
+                break;
+            case 'E':
+                initEvidence(optarg);
                 break;
 #ifdef USE_SSL
             case 'Z':

--- a/runPerf.ps1
+++ b/runPerf.ps1
@@ -1,4 +1,4 @@
-﻿param ($h, $s, $c, $p, $n, $conf, $k=1)
+﻿param ($h, $s, $c, $p, $n, $conf, $k=1, $E)
 
 $scriptRoot = Split-Path -Parent -Path $MyInvocation.MyCommand.Definition
 
@@ -42,6 +42,15 @@ Write-Host "Calibration Endpoint     = $c"
 Write-Host "Process Endpoint         = $p"
 Write-Host "Concurrency              = $k"
 
+# Send a full set of headers from each record of the evidence file when one
+# is given, otherwise rotate the User-Agents file as before.
+if ($E -ne $null) {
+    $sourceArg = "-E $E"
+    Write-Host "Evidence                 = $E"
+} else {
+    $sourceArg = "-U $ScriptRoot/uas.csv"
+}
+
 Write-Host "Starting the service"
 $serviceProcess = Start-Process pwsh -argument "-command `"$s`"" -RedirectStandardError "$scriptRoot/service-$conf.error.out" -RedirectStandardOutput "$scriptRoot/service-$conf.out" –PassThru -NoNewWindow
 
@@ -68,9 +77,9 @@ While ($HTTP_Status -ne 200 -And $Tries -le 12) {
 
 # Run the benchmarks
 Write-Host "Running calibration"
-Invoke-Expression "$ab -U $ScriptRoot/uas.csv -q -c $k -n $n $h/$c >$calOut"
+Invoke-Expression "$ab $sourceArg -q -c $k -n $n $h/$c >$calOut"
 Write-Host "Running processing"
-Invoke-Expression "$ab -U $ScriptRoot/uas.csv -q -c $k -n $n $h/$p >$proOut"
+Invoke-Expression "$ab $sourceArg -q -c $k -n $n $h/$p >$proOut"
 
 # Check no requests failed in calibration
 $failedCal = Get-Content $calOut | Select-String -Pattern "Failed requests"

--- a/runPerf.sh
+++ b/runPerf.sh
@@ -8,6 +8,7 @@ AB=`dirname $0`/ab
 UAS=`dirname $0`/uas.csv
 ALLOWED_OVERHEAD_MS=200
 CONCURRENCY=1
+EVIDENCE=
 
 while [[ $# -gt 0 ]]
 do
@@ -44,6 +45,11 @@ case $key in
     shift # past argument
     shift # past value
     ;;
+    -E|--evidence)
+    EVIDENCE="$2"
+    shift # past argument
+    shift # past value
+    ;;
     *)    # unknown option
     shift # past argument
     ;;
@@ -61,6 +67,7 @@ then
     echo "    -c | --calibration-endpoint   : endpoint path to use for calibration on the host e.g. test/calibrate"
     echo "    -p | --process-endpoint       : endpoint path to use for the process pass on the host e.g. test/process"
     echo "    -k | --concurrency            : number of concurrent requests to make (default 1)"
+    echo "    -E | --evidence               : YAML evidence file to send as request headers, used instead of the default User-Agents file"
 	echo ""
 	echo "For example:"
 	echo "    runPerf.bat -host localhost:3000 -passes 1000 -service-start \"php -S localhost:3000\" ..."
@@ -73,6 +80,16 @@ echo "Service Start            = ${SERVICE_START}"
 echo "Calibration Endpoint     = ${CAL_END}"
 echo "Process Endpoint         = ${PRO_END}"
 echo "Concurrency              = ${CONCURRENCY}"
+
+# Send a full set of headers from each record of the evidence file when one
+# is given, otherwise rotate the User-Agents file as before.
+if [[ -n ${EVIDENCE} ]]
+then
+    SOURCE_ARG="-E ${EVIDENCE}"
+    echo "Evidence                 = ${EVIDENCE}"
+else
+    SOURCE_ARG="-U ${UAS}"
+fi
 
 # Function for arithmetic
 calc() { awk "BEGIN{print $*}"; }
@@ -98,9 +115,9 @@ fi
 
 # Run the benchmarks
 echo "Running calibration"
-$AB -U $UAS -q -c $CONCURRENCY -n $PASSES $HOST/$CAL_END >$CAL_OUT
+$AB $SOURCE_ARG -q -c $CONCURRENCY -n $PASSES $HOST/$CAL_END >$CAL_OUT
 echo "Running processing"
-$AB -U $UAS -q -c $CONCURRENCY -n $PASSES $HOST/$PRO_END >$PRO_OUT
+$AB $SOURCE_ARG -q -c $CONCURRENCY -n $PASSES $HOST/$PRO_END >$PRO_OUT
 
 # Stop the service
 kill $SERVICE_PID


### PR DESCRIPTION
## Summary

ApacheBench could only vary the User-Agent header per request (the `-U` option), so a device detection benchmark exercised User-Agent matching alone. Real detection also uses other headers, notably the `Sec-CH-UA` client hints, and the other 51Degrees API benchmarks run against the full evidence records, not User-Agents only. This makes the NGINX benchmark use the same evidence as the rest.

## Change

- New `-E <file>` option for `ab`: loads a YAML evidence file as published in [device-detection-data](https://github.com/51Degrees/device-detection-data) (e.g. `20000 Evidence Records.yml`). The format is `---`-separated records, each a set of `header.<name>: <value>` lines. For each request `ab` picks a record at random and sends all of its headers in place of the default User-Agent line. Single-quoted YAML values are unquoted.
- `runPerf.sh`/`runPerf.ps1` gain a matching `-E` (Bash also `--evidence`) argument, used instead of the User-Agents file when given.
- README documents the option.
- Existing `-U` User-Agent usage is unchanged (default).

## Verification

Built `ab` and captured the raw requests it sends with `-E`:
- The parser reports the correct record count.
- A request drawn from a three-header record sends all three (`sec-ch-ua-mobile`, `user-agent`, `sec-ch-ua`), with the single-quoted `sec-ch-ua` value correctly unquoted (embedded quotes and comma preserved), and the default ApacheBench User-Agent removed.
- `runPerf.sh` passes `bash -n`; all committed files retain LF line endings.