### PR TITLE
Add UTM parameters to 51degrees.com links

### DIFF
--- a/.github/workflows/utm-link-lint.yml
+++ b/.github/workflows/utm-link-lint.yml
@@ -1,0 +1,25 @@
+name: UTM link lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  utm-link-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout common-ci
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/common-ci
+          path: utm-lint-common-ci
+
+      - name: Lint 51degrees.com links
+        shell: pwsh
+        run: ./utm-lint-common-ci/scripts/utm-lint.ps1 -RepoRoot .

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 51Degrees ApacheBench Fork
 
-![51Degrees](https://51degrees.com/DesktopModules/FiftyOne/Distributor/Logo.ashx?utm_source=github&utm_medium=repository&utm_content=home&utm_campaign=c-open-source "Data rewards the curious") **ApacheBench**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=apachebench&utm_content=readme.md&utm_term=51degrees-apachebench-fork "Data rewards the curious") **ApacheBench**
 
 
 A version of the Apache Benchmarking tool modified to randomly generate User-Agent headers. For more information on the original project including building this version see the [Apache HTTP server benchmarking tool](http://httpd.apache.org/docs/2.2/programs/ab.html) documentation.


### PR DESCRIPTION
Apply the standard UTM vocabulary to the 51Degrees-authored 51degrees.com link in this repository so the Content Team can trace traffic to its exact source.

## Changes
- README.md: retired `Logo.ashx` banner image URL replaced with `https://51degrees.com/img/logo.png` carrying the five-parameter UTM scheme (source=github, medium=readme, campaign=apachebench, content=readme.md, term=51degrees-apachebench-fork).

Only the 51Degrees-authored navigational banner link was tagged. Upstream Apache documentation links (httpd.apache.org, apachelounge.com, cmake.org) were left untouched.

## CI
Adds `.github/workflows/utm-link-lint.yml`, which checks out 51Degrees/common-ci and runs the shared UTM link lint on every PR and push to main. Lint passes locally.